### PR TITLE
Updated Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,5 +108,7 @@ venv.bak/
 
 # Voicefiles
 display_audio/
-display_video/
 voicefiles/
+
+# setup-files from the web
+get-pip.py

--- a/setup.sh
+++ b/setup.sh
@@ -30,6 +30,6 @@ command -v pip >/dev/null 2>&1 || {
 
 echo "Great, Pip is installed. Now we can proceed."
 
-pip install mutagen
-pip install python-vlc
+pip3 install mutagen
+pip3 install python-vlc
 


### PR DESCRIPTION
Setting up the Project caused an error, since pip was set up for python2.
The pip command was changed to pip3. On this way the python modules are installed for python3, which is also used for executing the application.

Also updated the .gitignore. `get-pip.py` is now ignored by git.